### PR TITLE
Infer `:source-paths` and `:test-paths` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This plugin accepts one of the following patterns:
 
 ``` bash
 $ # 1.- Analyse your project:
-$ lein with-profile +test clj-kondo --copy-configs --dependencies --lint $classpath
+$ lein with-profile +test clj-kondo --copy-configs --dependencies --parallel $classpath
 $ # 2.- Lint your source and test paths:
 $ lein with-profile +test clj-kondo
 ```
@@ -49,7 +49,7 @@ You can configure your project.clj to add custom aliases to run specific clj-kon
 
 ```clojure
 ,,,
-:aliases {"clj-kondo-deps" ["with-profile" "+test" "clj-kondo" "--copy-configs" "--dependencies" "--lint" "$classpath"]
+:aliases {"clj-kondo-deps" ["with-profile" "+test" "clj-kondo" "--copy-configs" "--dependencies" "--parallel" "$classpath"]
           "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["with-profile" "+test" "clj-kondo"]]}
 ,,,
 ```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 A Leiningen plugin to run [clj-kondo](https://github.com/clj-kondo/clj-kondo).
 
+## Rationale
+
+Running clj-kondo through Leiningen has some advantages, since it can compute for you things that would have to be specified by hand otherwise
+(and those things can be forgotten, outdated, etc).
+
+There's the tradeoff of startup speed, which might not be as critical in a CI environment as it is in your CLI.
+
 ## Installation
 
 Add the plugin to your `project.clj`:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ This plugin accepts one of the following patterns:
 
 ``` bash
 $ # 1.- Analyse your project:
-$ lein clj-kondo --copy-configs --dependencies --lint $classpath
+$ lein with-profile +test clj-kondo --copy-configs --dependencies --lint $classpath
 $ # 2.- Lint your source and test paths:
-$ lein clj-kondo
+$ lein with-profile +test clj-kondo
 ```
+
+Activating the `+test` profile is recommended, so that any `:test` dependencies are analysed, increasing linting accuracy.
+
+(Note that the `:dev` profile is already active by default)
 
 ### Aliases
 
@@ -45,8 +49,8 @@ You can configure your project.clj to add custom aliases to run specific clj-kon
 
 ```clojure
 ,,,
-:aliases {"clj-kondo-deps" ["clj-kondo" "--copy-configs" "--dependencies" "--lint" "$classpath"]
-          "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["clj-kondo"]]}
+:aliases {"clj-kondo-deps" ["with-profile" "+test" "clj-kondo" "--copy-configs" "--dependencies" "--lint" "$classpath"]
+          "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["with-profile" "+test" "clj-kondo"]]}
 ,,,
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,24 +14,32 @@ Add the plugin to your `project.clj`:
 
 ## Usage
 
-This plugin accepts the following pattern `clj-kondo <options>`.
+This plugin accepts one of the following patterns:
 
-For more information on all available options, Check the [documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md).
+* `lein clj-kondo`
+  * This lints your `:source-paths` and `:test-paths`, as computed by Leiningen.
+  * It is necessary that you have analysed the project beforehand (see below)
+* `lein clj-kondo <options>`
+  * This is a good place to analyse your project, or to lint directories other than the `:source-paths` and `:test-paths`.
+  * For more information on all available options, check the [documentation](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md).
 
-### lein CLI
+### Lein CLI
 
 ``` bash
-$ lein clj-kondo --lint $classpath
+$ # 1.- Analyse your project:
+$ lein clj-kondo --copy-configs --dependencies --lint $classpath
+$ # 2.- Lint your source and test paths:
+$ lein clj-kondo
 ```
 
 ### Aliases
 
-You can configure your project.clj to add custom aliases to run specific clj-kondo tasks, below you can find a simple example which first lint the project dependencies and then lint the project code:
+You can configure your project.clj to add custom aliases to run specific clj-kondo tasks, below you can find a simple example which first lints the project dependencies and then lints the project code:
 
 ```clojure
 ,,,
 :aliases {"clj-kondo-deps" ["clj-kondo" "--copy-configs" "--dependencies" "--lint" "$classpath"]
-          "clj-kondo" ["do" ["clj-kondo-deps"] ["clj-kondo" "--lint" "src" "test"]]}
+          "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["clj-kondo"]]}
 ,,,
 ```
 

--- a/src/leiningen/clj_kondo.clj
+++ b/src/leiningen/clj_kondo.clj
@@ -17,7 +17,7 @@
                    (into ["--lint"] v)))
         exit-status (apply kondo/main args)]
     (when-not (zero? exit-status)
-      (System/exit exit-status))))
+      (lein-core/exit exit-status))))
 
 (defn parse-additional [project options]
   (mapv (fn [option]


### PR DESCRIPTION
* Infer `:source-paths` and `:test-paths` by default
  * Fixes https://github.com/clj-kondo/lein-clj-kondo/issues/2
* Use `leiningen.core.main/exit`
  * Fixes https://github.com/clj-kondo/lein-clj-kondo/issues/3

I QAed this with a simple `lein install; lein clj-kondo; echo $?`

Cheers - V