### PR TITLE
README: fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This plugin accepts one of the following patterns:
 
 ``` bash
 $ # 1.- Analyse your project:
-$ lein with-profile +test clj-kondo --copy-configs --dependencies --parallel $classpath
+$ lein with-profile +test clj-kondo --copy-configs --dependencies --parallel --lint '$classpath'
 $ # 2.- Lint your source and test paths:
 $ lein with-profile +test clj-kondo
 ```
@@ -49,7 +49,7 @@ You can configure your project.clj to add custom aliases to run specific clj-kon
 
 ```clojure
 ,,,
-:aliases {"clj-kondo-deps" ["with-profile" "+test" "clj-kondo" "--copy-configs" "--dependencies" "--parallel" "$classpath"]
+:aliases {"clj-kondo-deps" ["with-profile" "+test" "clj-kondo" "--copy-configs" "--dependencies" "--parallel" "--lint" "$classpath"]
           "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["with-profile" "+test" "clj-kondo"]]}
 ,,,
 ```


### PR DESCRIPTION
* `--lint` is needed before specifying the classpath
* Quote `$classpath`, else a terminal will try evaluating it

QAed, it creates a .cache dir as intended

Cheers - V