### PR TITLE
Translate :clj-kondo config expressed in Leiningen project maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A Leiningen plugin to run [clj-kondo](https://github.com/clj-kondo/clj-kondo).
 Running clj-kondo through Leiningen has some advantages, since it can compute for you things that would have to be specified by hand otherwise
 (and those things can be forgotten, outdated, etc).
 
-There's the tradeoff of startup speed, which might not be as critical in a CI environment as it is in your CLI.
+It also provides the ability to express clj-kondo options as Lein project map options, which can work nicely with Lein profiles, plugins, etc. 
+
+With using Leiningen, there's the tradeoff of startup speed, which might not be as critical in a CI environment as it is in your CLI.
 
 ## Installation
 
@@ -53,6 +55,20 @@ You can configure your project.clj to add custom aliases to run specific clj-kon
           "clj-kondo-lint" ["do" ["clj-kondo-deps"] ["with-profile" "+test" "clj-kondo"]]}
 ,,,
 ```
+
+## Config
+
+lein-clj-kondo understands clj-kondo config expressed as `:config` in a Leiningen project map. Example:
+
+```clj
+;; Enable a specific linter
+:clj-kondo {:config {:linters {:docstring-leading-trailing-whitespace {:level :warning}}}}
+```
+
+The traditional ways of specifying options of course keep working:
+
+* You can place a `.clj-kondo/config.edn` file in your project.
+* You can use the `--config ...` CLI option.
 
 ### Deploy
 

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true
   :pedantic? :warn
-  :dependencies [[clj-kondo/clj-kondo "2022.04.25"]]
+  :dependencies [[clj-kondo/clj-kondo "2022.06.22"]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password

--- a/src/leiningen/clj_kondo.clj
+++ b/src/leiningen/clj_kondo.clj
@@ -6,7 +6,9 @@
   (:import
    (java.io File)))
 
-(defn ^:private run-kondo! [{:keys [source-paths test-paths]} options]
+(defn ^:private run-kondo! [{:keys [source-paths test-paths]
+                             {:keys [config]} :clj-kondo}
+                            options]
   (let [args (or (not-empty options)
                  (when-let [v (->> [source-paths test-paths]
                                    (reduce into [])
@@ -15,6 +17,8 @@
                                    (not-empty))]
                    (apply lein-core/info "Linting" v)
                    (into ["--lint"] v)))
+        args (cond-> args
+               config (conj "--config" config))
         exit-status (apply kondo/main args)]
     (when-not (zero? exit-status)
       (lein-core/exit exit-status))))


### PR DESCRIPTION
Closes https://github.com/clj-kondo/lein-clj-kondo/issues/8

The feature can be tested out like so:

```diff
diff --git a/project.clj b/project.clj
index 8a50fb1..a1fa9cb 100644
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :eval-in-leiningen true
   :pedantic? :warn
   :dependencies [[clj-kondo/clj-kondo "2022.06.22"]]
+  :clj-kondo {:config {:linters {:docstring-leading-trailing-whitespace {:level :warning}}}}
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password
diff --git a/src/leiningen/clj_kondo.clj b/src/leiningen/clj_kondo.clj
index a97e353..344c1f8 100644
--- a/src/leiningen/clj_kondo.clj
+++ b/src/leiningen/clj_kondo.clj
@@ -23,7 +23,10 @@
     (when-not (zero? exit-status)
       (lein-core/exit exit-status))))
 
-(defn parse-additional [project options]
+(defn parse-additional
+  "Hello
+  "
+  [project options]
   (mapv (fn [option]
           (if (= "$classpath" option)
             (lein-classpath/get-classpath-string project)
```

```bash
$ lein clj-kondo
/Users/vemv/lein-clj-kondo/src/leiningen/clj_kondo.clj:27:3: warning: Docstring should not have leading or trailing whitespace.
linting took 99ms, errors: 0, warnings: 1
```

Cheers - V