### PR TITLE
Add help message in lein help command

### DIFF
--- a/src/leiningen/clj_kondo.clj
+++ b/src/leiningen/clj_kondo.clj
@@ -32,7 +32,8 @@
         options))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
-(defn ^:no-project-needed clj-kondo
+(defn ^:no-project-needed ^:pass-through-help clj-kondo
+  "Run the clj-kondo linter on a project."
   [project & options]
   (let [options (parse-additional project options)]
     (if lein-core/*info*


### PR DESCRIPTION
Most plugins will display a short summary of what they do. In this case, we write a simple docstring to describe what the clj-kondo task does.