### PR TITLE
Update project URL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject com.github.clj-kondo/lein-clj-kondo "2025.04.07"
   :description "Lein plugin to run clj-kondo"
-  :url "https://clj-kondo.github.io/clj-kondo"
+  :url "https://github.com/clj-kondo/lein-clj-kondo"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :eval-in-leiningen true


### PR DESCRIPTION
this metadata is used in `HomePage`
Without this change, it is hard to find the project from the artifact.